### PR TITLE
add kasperlewau/angular-bind-notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Table of contents:
 * [angular-js.in](http://angular-js.in/) - A curated collection of angular directives
 * [mgechev/angularjs-in-patterns](https://github.com/mgechev/angularjs-in-patterns) - This repository provides different look into AngularJS.
 * [Gillespie59/eslint-plugin-angular](https://github.com/Gillespie59/eslint-plugin-angular) - ESLint plugin for AngularJS application
+* [kasperlewau/angular-bind-notifier](https://github.com/kasperlewau/angular-bind-notifier) - Low $watch count namespaced Angular bindings, i.e. refreshment of one-way binds.
 
 ## License
 


### PR DESCRIPTION
I put this under `other` as the API supplied by the package in question can be used in multiple ways; 

* As a `new`'ed instance of a factoryFn. 
* As an attribute directive. 
* With a manual call to `$broadcast`. 

Figured it didn't fit the `directive` and/or `service` bill, and even so - it doesn't *quite* fit into the `other` category either. I'll gladly edit the position in the list if you feel it belongs somewhere else. 