### PR TITLE
Updated to a standard format and checked all links.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Please ensure your pull request adheres to the following guidelines:
 - Keep descriptions short and simple, but descriptive.
 - End all descriptions with a full stop/period.
 - Check your spelling and grammar.
+- Use "AngularJS" as the correct spelling and capitalization for the framework.
 - Make sure your text editor is set to remove trailing whitespace.
 
 Thank you for your suggestions!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Awesome AngularJs [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
-A list of awesome [AngularJs](https://angularjs.org/) services, directives, utilities and resources.
+# Awesome AngularJS [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+A list of awesome [AngularJS](https://angularjs.org/) services, directives, utilities and resources.
 
 Table of contents:
 * [Seed Projects](#seed-projects)
@@ -23,173 +23,172 @@ Table of contents:
 ## Seed Projects
 * [ngbp/ngbp](https://github.com/ngbp/ngbp) - A sophisticated build management system for web apps
 * [vesparny/angular-kickstart](https://github.com/vesparny/angular-kickstart) - Speed up your AngularJS development and testing with a complete and scalable build system that scaffolds the project for you.
-* [okigan/angular-sensible-seed](https://github.com/okigan/angular-sensible-seed)  - Opinionated angular starter project with per feature directory structure, static content, gulp build system, integrated logo/search/ui-router/ui-bootstrap/less.
-* [angular/angular-seed](https://github.com/angular/angular-seed) - Seed project for angular apps.
-* [vesparny/angularjs-playground](https://github.com/vesparny/angularjs-playground) - A starting point that follows best-practices, for being up and running in minutes with angularJS
-* [kmaida/reStart-angular](https://github.com/kmaida/reStart-angular) - Responsive AngularJS seed project following styleguide best practices
-* [StarterSquad/ngSeed](https://github.com/StarterSquad/ngseed) - AngularJS/RequireJS seed project
+* [okigan/angular-sensible-seed](https://github.com/okigan/angular-sensible-seed)  - Opinionated AngularJS starter project with per feature directory structure, static content, gulp build system, integrated logo/search/ui-router/ui-bootstrap/less.
+* [angular/angular-seed](https://github.com/angular/angular-seed) - Seed project for AngularJS apps.
+* [vesparny/angularjs-playground](https://github.com/vesparny/angularjs-playground) - A starting point that follows best-practices, for being up and running in minutes with AngularJS.
+* [kmaida/reStart-angular](https://github.com/kmaida/reStart-angular) - Responsive AngularJS seed project following styleguide best practices.
+* [StarterSquad/ngSeed](https://github.com/StarterSquad/ngseed) - AngularJS/RequireJS seed project.
 * [tnajdek/angular-requirejs-seed](https://github.com/tnajdek/angular-requirejs-seed) - This is a fork of Angular Seed but with changes needed for requireJS support.
 * [btford/angular-express-blog](https://github.com/btford/angular-express-blog) - Example AngularJS app using an Express + Node.js backend.
 * [btford/angular-socket-io-seed](https://github.com/btford/angular-socket-io-seed) - A great starting point for writing AngularJS apps backed by a Socket.io-powered node.js server.
-* [ziyasal/ratchet-angular-seed](https://github.com/ziyasal/ratchet-angular-seed) - Seed project for Angular & Ratchet apps.
-* [jesalg/RADD](https://github.com/jesalg/RADD) - Example AngularJS app using Rails and Devise authentication gem
-* [linemanjs/lineman-angular-template](https://github.com/linemanjs/lineman-angular-template) - This is a project template for Angular JS applications using Lineman.
-* [meanjs/mean](https://github.com/meanjs/mean) - Mongo + ExpressJS + AngularJS + NodeJS boilerplate
-* [linnovate/mean](https://github.com/linnovate/mean) - Mongo + ExpressJS + AngularJS + NodeJS boilerplate by Linnovate
-* [melvin0008/laravel-angular](https://github.com/melvin0008/laravel-angular) - Laravel + AngularJS + CouchDB boilerplate by Melvin
-* [giorgiofellipe/ionic-angular-parse-boilerplate](https://github.com/giorgiofellipe/ionic-angular-parse-boilerplate) - Ionic + AngularJS + Parse.com boilerplate by Giorgio Fellipe
-* [the-front/angularjs-ee-boilerplate](https://github.com/the-front/angularjs-ee-boilerplate) - This boilerplate (seed project, starting project) helps you build large scale Angular.js applications with Require.js by Erko Bridee
+* [ziyasal/ratchet-angular-seed](https://github.com/ziyasal/ratchet-angular-seed) - Seed project for AngularJS & Ratchet apps.
+* [jesalg/RADD](https://github.com/jesalg/RADD) - Example AngularJS app using Rails and Devise authentication gem.
+* [linemanjs/lineman-angular-template](https://github.com/linemanjs/lineman-angular-template) - This is a project template for AngularJS applications using Lineman.
+* [meanjs/mean](https://github.com/meanjs/mean) - Mongo + ExpressJS + AngularJS + NodeJS boilerplate.
+* [linnovate/mean](https://github.com/linnovate/mean) - Mongo + ExpressJS + AngularJS + NodeJS boilerplate by Linnovate.
+* [melvin0008/laravel-angular](https://github.com/melvin0008/laravel-angular) - Laravel + AngularJS + CouchDB boilerplate by Melvin.
+* [giorgiofellipe/ionic-angular-parse-boilerplate](https://github.com/giorgiofellipe/ionic-angular-parse-boilerplate) - Ionic + AngularJS + Parse.com boilerplate by Giorgio Fellipe.
+* [the-front/angularjs-ee-boilerplate](https://github.com/the-front/angularjs-ee-boilerplate) - This boilerplate (seed project, starting project) helps you build large scale AngularJS applications with Require.js by Erko Bridee.
 
 ## User Manager
-* [lynndylanhurley/ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth) - Token based authentication module for angular.js
-* [andreareginato/oauth-ng](https://github.com/andreareginato/oauth-ng) - AngularJS directive for the OAuth 2.0 Implicit Flow
-* [enginous/angular-oauth](https://github.com/angular-oauth/angular-oauth) - Client-side (implicit grant) OAuth 2.0 authorization flow for AngularJS
-* [witoldsz/angular-http-auth](https://github.com/witoldsz/angular-http-auth) - HTTP Auth Interceptor Module
-* [sahat/satellizer](https://github.com/sahat/satellizer) - Token-based AngularJS Authentication
+* [lynndylanhurley/ng-token-auth](https://github.com/lynndylanhurley/ng-token-auth) - Token based authentication module for AngularJS.
+* [andreareginato/oauth-ng](https://github.com/andreareginato/oauth-ng) - AngularJS directive for the OAuth 2.0 Implicit Flow.
+* [enginous/angular-oauth](https://github.com/angular-oauth/angular-oauth) - Client-side (implicit grant) OAuth 2.0 authorization flow for AngularJS.
+* [witoldsz/angular-http-auth](https://github.com/witoldsz/angular-http-auth) - HTTP Auth Interceptor Module.
+* [sahat/satellizer](https://github.com/sahat/satellizer) - Token-based AngularJS Authentication.
 
 ## Mobile
-* [ajoslin/angular-mobile-nav](https://github.com/ajoslin/angular-mobile-nav) - An angular navigation service for mobile applications
-* [driftyco/ng-cordova](https://github.com/driftyco/ng-cordova/) - AngularJS Cordova wrappers for common Cordova plugins
-* [revolunet/angular-carousel](https://github.com/revolunet/angular-carousel) - Mobile friendly AngularJS carousel
-* [driftyco/ionic](https://github.com/driftyco/ionic) - Advanced HTML5 Hybrid Mobile App Framework
+* [ajoslin/angular-mobile-nav](https://github.com/ajoslin/angular-mobile-nav) - An AngularJS navigation service for mobile applications.
+* [driftyco/ng-cordova](https://github.com/driftyco/ng-cordova/) - AngularJS Cordova wrappers for common Cordova plugins.
+* [revolunet/angular-carousel](https://github.com/revolunet/angular-carousel) - Mobile friendly AngularJS carousel.
+* [driftyco/ionic](https://github.com/driftyco/ionic) - Advanced HTML5 Hybrid Mobile App Framework.
 
 ## Web Service
-* [mgonto/restangular](https://github.com/mgonto/restangular) - AngularJS service to handle Rest API Restful Resources properly and easily
-* [chinmaymk/angular-cog](https://github.com/chinmaymk/angular-cog) - declarative ajax requests for angularjs
-* [tkambler/bonegular](https://github.com/tkambler/bonegular) - Backbone-Inspired Models and Collections for Angular
-* [platanus/angular-restmod](https://github.com/platanus/angular-restmod) - Rails inspired REST-API ORM for Angular
+* [mgonto/restangular](https://github.com/mgonto/restangular) - AngularJS service to handle Rest API Restful Resources properly and easily.
+* [chinmaymk/angular-cog](https://github.com/chinmaymk/angular-cog) - declarative ajax requests for AngularJS.
+* [tkambler/bonegular](https://github.com/tkambler/bonegular) - Backbone-Inspired Models and Collections for AngularJS.
+* [platanus/angular-restmod](https://github.com/platanus/angular-restmod) - Rails inspired REST-API ORM for AngularJS.
 
 ## Asset Manager
-* [danialfarid/angular-file-upload](https://github.com/danialfarid/ng-file-upload) - An AngularJS directive for file upload using HTML5 with FileAPI polyfill for unsupported browsers
-* [urish/angular-load](https://github.com/urish/angular-load) - Dynamically load scripts and css stylesheets in your Angular.JS app
-* [flowjs/ng-flow](https://github.com/flowjs/ng-flow) - Flow.js html5 file upload extension on angular.js framework
+* [danialfarid/angular-file-upload](https://github.com/danialfarid/ng-file-upload) - An AngularJS directive for file upload using HTML5 with FileAPI polyfill for unsupported browsers.
+* [urish/angular-load](https://github.com/urish/angular-load) - Dynamically load scripts and css stylesheets in your AngularJS app.
+* [flowjs/ng-flow](https://github.com/flowjs/ng-flow) - Flow.js html5 file upload extension on AngularJS framework.
 
 ## Routing
-* [angular-ui/ui-utils](https://github.com/angular-ui/ui-utils) - Swiss-Army-Knife of AngularJS tools
-
+* [angular-ui/ui-router](https://github.com/angular-ui/ui-router) - The de-facto solution to flexible routing with nested views in AngularJS.
 
 ## Filter
-* [jdpedrie/angularjs-camelCase-to-human-filter](https://github.com/jdpedrie/angularjs-camelCase-to-human-filter) - AngularJS Filter to convert camelCase strings to human readable strings
+* [jdpedrie/angularjs-camelCase-to-human-filter](https://github.com/jdpedrie/angularjs-camelCase-to-human-filter) - AngularJS Filter to convert camelCase strings to human readable strings.
 
 ## Directive
-* [zizzamia/ng-tasty](https://github.com/zizzamia/ng-tasty) - Lightweight, flexible, and tasty collection of reusable UI components for AngularJS, like grandma used to make. ( table directive, range filter )
+* [zizzamia/ng-tasty](https://github.com/zizzamia/ng-tasty) - Lightweight, flexible, and tasty collection of reusable UI components for AngularJS, like grandma used to make. ( table directive, range filter ).
 * [tombatossals/angular-leaflet-directive](https://github.com/tombatossals/angular-leaflet-directive) - AngularJS directive to embed and interact with maps managed by Leaflet library.
-* [esvit/angular-social](https://github.com/esvit/angular-social) - Social like-buttons with counters for sites (even ajax sites)
-* [sroze/ngInfiniteScroll](https://github.com/sroze/ngInfiniteScroll/) - Infinite Scrolling for AngularJS
-* [fraywing/textAngular/](https://github.com/fraywing/textAngular/) - A radically powerful Text-Editor/Wysiwyg editor for Angular.js! Create multiple editor instances, two-way-bind HTML content, watch editors for changes and more!
-* [cgross/angular-busy](https://github.com/cgross/angular-busy) - Show busy/loading indicators on any element during $http requests
+* [esvit/angular-social](https://github.com/esvit/angular-social) - Social like-buttons with counters for sites (even ajax sites).
+* [sroze/ngInfiniteScroll](https://github.com/sroze/ngInfiniteScroll/) - Infinite Scrolling for AngularJS.
+* [fraywing/textAngular/](https://github.com/fraywing/textAngular/) - A radically powerful Text-Editor/Wysiwyg editor for AngularJS! Create multiple editor instances, two-way-bind HTML content, watch editors for changes and more!
+* [cgross/angular-busy](https://github.com/cgross/angular-busy) - Show busy/loading indicators on any element during $http requests.
 * [lavinjj/angularjs-gravatardirective](https://github.com/lavinjj/angularjs-gravatardirective) - An AngularJS Gravatar Image Directive.
-* [Venturocket/angular-slider](https://github.com/Venturocket/angular-slider) - Slider directive for AngularJS
-* [passy/angular-masonry](https://github.com/passy/angular-masonry) - An AngularJS directive for Masonry
-* [siddii/angular-timer](https://github.com/siddii/angular-timer) - re-usable/inter-operable AngularJS timer directive
-* [ajoslin/angular-scrolly](https://github.com/ajoslin/angular-scrolly) - Fake transform-scrolling with angular-friendly utilities
-* [djds4rce/angular-socialshare](https://github.com/djds4rce/angular-socialshare) - social share buttons for angularjs
-* [blackgate/bg-splitter](https://github.com/blackgate/bg-splitter) - Simple pane splitter for angular.js
-* [fullscale/dangle](https://github.com/fullscale/dangle) - A set of AngularJS directives that provide common D3 visualizations for elasticsearch
-* [angular-ui/ui-tinymce](https://github.com/angular-ui/ui-tinymce) - AngularUI wrapper for TinyMCE
-* [angular-ui/bootstrap](https://github.com/angular-ui/bootstrap) - Native AngularJS (Angular) directives for Bootstrap. Small footprint (5kB gzipped!), no 3rd party JS dependencies (jQuery, bootstrap JS) required!
-* [chieffancypants/angular-hotkeys](https://github.com/chieffancypants/angular-hotkeys) - Configuration-centric keyboard shortcuts for your Angular apps
-* [marcorinck/angular-growl](https://github.com/marcorinck/angular-growl) - growl-like notifications for angularJS projects
-* [urish/angular-spinner](https://github.com/urish/angular-spinner) - Angular directive to show an animated spinner
-* [codef0rmer/angular-dragdrop](https://github.com/codef0rmer/angular-dragdrop) - Drag and Drop for AngularJS (with Animation)
-* [asafdav/ng-csv](https://github.com/asafdav/ng-csv) - Simple directive that turns arrays and objects into downloadable CSV files
-* [angular-widgets/angular-jqm](https://github.com/angular-widgets/angular-jqm) - AngularJS directives for jQuery Mobile
-* [chieffancypants/angular-loading-bar](https://github.com/chieffancypants/angular-loading-bar) - A fully automatic loading / progress bar for your angular apps.
-* [angular-ui/ui-select](https://github.com/angular-ui/ui-select) - AngularJS-native version of Select2 and Selectize
+* [Venturocket/angular-slider](https://github.com/Venturocket/angular-slider) - Slider directive for AngularJS.
+* [passy/angular-masonry](https://github.com/passy/angular-masonry) - An AngularJS directive for Masonry.
+* [siddii/angular-timer](https://github.com/siddii/angular-timer) - re-usable/inter-operable AngularJS timer directive.
+* [ajoslin/angular-scrolly](https://github.com/ajoslin/angular-scrolly) - Fake transform-scrolling with AngularJS-friendly utilities.
+* [djds4rce/angular-socialshare](https://github.com/djds4rce/angular-socialshare) - social share buttons for AngularJS.
+* [blackgate/bg-splitter](https://github.com/blackgate/bg-splitter) - Simple pane splitter for AngularJS.
+* [fullscale/dangle](https://github.com/fullscale/dangle) - A set of AngularJS directives that provide common D3 visualizations for elasticsearch.
+* [angular-ui/ui-tinymce](https://github.com/angular-ui/ui-tinymce) - AngularUI wrapper for TinyMCE.
+* [angular-ui/bootstrap](https://github.com/angular-ui/bootstrap) - Native AngularJS directives for Bootstrap. Small footprint (5kB gzipped!), no 3rd party JS dependencies (jQuery, bootstrap JS) required!
+* [chieffancypants/angular-hotkeys](https://github.com/chieffancypants/angular-hotkeys) - Configuration-centric keyboard shortcuts for your AngularJS apps.
+* [marcorinck/angular-growl](https://github.com/marcorinck/angular-growl) - growl-like notifications for angularJS projects.
+* [urish/angular-spinner](https://github.com/urish/angular-spinner) - AngularJS directive to show an animated spinner.
+* [codef0rmer/angular-dragdrop](https://github.com/codef0rmer/angular-dragdrop) - Drag and Drop for AngularJS (with Animation).
+* [asafdav/ng-csv](https://github.com/asafdav/ng-csv) - Simple directive that turns arrays and objects into downloadable CSV files.
+* [angular-widgets/angular-jqm](https://github.com/angular-widgets/angular-jqm) - AngularJS directives for jQuery Mobile.
+* [chieffancypants/angular-loading-bar](https://github.com/chieffancypants/angular-loading-bar) - A fully automatic loading / progress bar for your AngularJS apps.
+* [angular-ui/ui-select](https://github.com/angular-ui/ui-select) - AngularJS-native version of Select2 and Selectize.
 * [btford/angular-markdown-directive](https://github.com/btford/angular-markdown-directive) - AngularJS markdown directive using Showdown.js
-* [yunlzheng/angular-knob](https://github.com/yunlzheng/angular-knob) - angular directive of jquery knob
-* [c0bra/angular-responsive-images](https://github.com/c0bra/angular-responsive-images) - Angular responsive images
-* [angular-ui/ui-sortable](https://github.com/angular-ui/ui-sortable) - AngularJS bindings for jQuery UI Sortable
-* [durated/angular-scroll](https://github.com/durated/angular-scroll) - Scrollspy, animated scrollTo and scroll events for angular.js
-* [jeffling/ng-tether](https://github.com/jeffling/angular-jl-tether) - Angular wrapper for Tether: make absolutely positioned elements attach to elements in the page efficiently
-* [unosquare/tubular](https://github.com/unosquare/tubular) -AngularJS directives for grids and forms
-* [matowens/ng-notify](https://github.com/matowens/ng-notify) - A simple, lightweight module for displaying notifications in your AngularJS app
-* [dragular](https://github.com/luckylooke/dragular) - Angular drag and drop based on dragula.js
+* [yunlzheng/angular-knob](https://github.com/yunlzheng/angular-knob) - angular directive of jquery knob.
+* [c0bra/angular-responsive-images](https://github.com/c0bra/angular-responsive-images) - AngularJS responsive images.
+* [angular-ui/ui-sortable](https://github.com/angular-ui/ui-sortable) - AngularJS bindings for jQuery UI Sortable.
+* [durated/angular-scroll](https://github.com/durated/angular-scroll) - Scrollspy, animated scrollTo and scroll events for AngularJS.
+* [jeffling/ng-tether](https://github.com/jeffling/angular-jl-tether) - AngularJS wrapper for Tether: make absolutely positioned elements attach to elements in the page efficiently.
+* [unosquare/tubular](https://github.com/unosquare/tubular) -AngularJS directives for grids and forms.
+* [matowens/ng-notify](https://github.com/matowens/ng-notify) - A simple, lightweight module for displaying notifications in your AngularJS app.
+* [dragular](https://github.com/luckylooke/dragular) - AngularJS drag and drop based on dragula.js.
 * [hrajchert/angular-screenfull](https://github.com/hrajchert/angular-screenfull) - Binding to use the HTML5 fullscreen API using directives and directives controllers.
-* [StevenLambion/ui-listView](https://github.com/StevenLambion/ui-listView) - An efficient, dynamic list view for angular.
-* [Sattvabit/angular-material-checkbox](https://github.com/Sattvabit/angular-material-checkbox) - Simple angular check-box/toggle button directive using Google material design icons.
-* * [tushariscoolster/ng-sweet-alert](https://github.com/tushariscoolster/ng-sweet-alert) - Sweetalert directive for angular js( angular sweetalert), without writing single javascript code.
+* [StevenLambion/ui-listView](https://github.com/StevenLambion/ui-listView) - An efficient, dynamic list view for AngularJS.
+* [Sattvabit/angular-material-checkbox](https://github.com/Sattvabit/angular-material-checkbox) - Simple AngularJS check-box/toggle button directive using Google material design icons.
+* [tushariscoolster/ng-sweet-alert](https://github.com/tushariscoolster/ng-sweet-alert) - Sweetalert directive for AngularJS, without writing single javascript code.
 
 ## Storage
 * [gsklee/ngStorage](https://github.com/gsklee/ngStorage) - localStorage and sessionStorage done right for AngularJS.
-* [grevory/angular-local-storage](https://github.com/grevory/angular-local-storage) - An AngularJS module that gives you access to the browsers local storage with cookie fallback
-* [jmdobry/angular-cache](https://github.com/jmdobry/angular-cache) - angular-cache is a very useful replacement for Angular's $cacheFactory.
-* [jmdobry/angular-data](https://github.com/js-data/js-data-angular) - Data store for Angular.js
-* [webcss/angular-indexedDB](https://github.com/webcss/angular-indexedDB) - An angularjs serviceprovider to utilize indexedDB with angular
+* [grevory/angular-local-storage](https://github.com/grevory/angular-local-storage) - An AngularJS module that gives you access to the browsers local storage with cookie fallback.
+* [jmdobry/angular-cache](https://github.com/jmdobry/angular-cache) - angular-cache is a very useful replacement for AngularJS's $cacheFactory.
+* [jmdobry/angular-data](https://github.com/js-data/js-data-angular) - Data store for AngularJS.
+* [webcss/angular-indexedDB](https://github.com/webcss/angular-indexedDB) - An AngularJS serviceprovider to utilize indexedDB with AngularJS.
 
 ## Data Manage
-* [esvit/ng-table](https://github.com/esvit/ng-table) - Simple table with sorting and filtering on AngularJS
-* [huei90/angular-validation](https://github.com/huei90/angular-validation) - Client-side Validation for AngularJS
-* [formly-js/angular-formly](https://github.com/formly-js/angular-formly) - JavaScript powered forms
-* [kelp404/angular-validator](https://github.com/kelp404/angular-validator) - AngularJS form validation
-* [Textalk/angular-schema-form](https://github.com/Textalk/angular-schema-form) - Generate forms from a JSON schema, with AngularJS
-* [angular-ui/ng-grid](https://github.com/angular-ui/ui-grid) - UI Grid: an Angular Data Grid
+* [esvit/ng-table](https://github.com/esvit/ng-table) - Simple table with sorting and filtering on AngularJS.
+* [huei90/angular-validation](https://github.com/huei90/angular-validation) - Client-side Validation for AngularJS.
+* [formly-js/angular-formly](https://github.com/formly-js/angular-formly) - JavaScript powered forms.
+* [kelp404/angular-validator](https://github.com/kelp404/angular-validator) - AngularJS form validation.
+* [Textalk/angular-schema-form](https://github.com/Textalk/angular-schema-form) - Generate forms from a JSON schema, with AngularJS.
+* [angular-ui/ng-grid](https://github.com/angular-ui/ui-grid) - UI Grid: an AngularJS Data Grid.
 * [jbroquist/parse-angular](https://github.com/jbroquist/parse-angular) - Utilities for working with Parse.com data.
-* [jimrhoskins/angular-parse](https://github.com/jimrhoskins/angular-parse) - Module for interacting with the Parse REST API
-* [laurihy/angular-payments](https://github.com/laurihy/angular-payments) - Module that provides AngularJS-directives for formatting, validating and working with payments
-* [lorenzofox3/Smart-Table](https://github.com/lorenzofox3/Smart-Table) - a table/grid for AngularJS
-* [vitalets/angular-xeditable](https://github.com/vitalets/angular-xeditable) - Edit in place for AngularJS
-* [MoonStorm/trNgGrid](https://github.com/MoonStorm/trNgGrid) - A feature rich Angular grid using standard HTML tables
+* [jimrhoskins/angular-parse](https://github.com/jimrhoskins/angular-parse) - Module for interacting with the Parse REST API.
+* [laurihy/angular-payments](https://github.com/laurihy/angular-payments) - Module that provides AngularJS-directives for formatting, validating and working with payments.
+* [lorenzofox3/Smart-Table](https://github.com/lorenzofox3/Smart-Table) - a table/grid for AngularJS.
+* [vitalets/angular-xeditable](https://github.com/vitalets/angular-xeditable) - Edit in place for AngularJS.
+* [MoonStorm/trNgGrid](https://github.com/MoonStorm/trNgGrid) - A feature rich AngularJS grid using standard HTML tables.
 * [ceolter/ag-grid](https://github.com/ceolter/ag-grid) - Advanced Datagrid for Pure Javascript/AngularJS 1.x/AngularJS 2/Web Components.
-* [mattiash/angular-tablesort](https://github.com/mattiash/angular-tablesort) - Sort angularjs tables easily
+* [mattiash/angular-tablesort](https://github.com/mattiash/angular-tablesort) - Sort AngularJS tables easily.
 
 ## Developer
-* [angular/protractor](https://github.com/angular/protractor) - E2E test framework for Angular apps
-* [matthieu-D/angular-lorem-image](https://github.com/matthieu-D/angular-lorem-image) - This directive provides lorem image generation for your website by using the great lorempixel service to generate images
-* [ajoslin/angular-promise-tracker](https://github.com/ajoslin/angular-promise-tracker) - Easily add spinners or general request tracking to your angular app
-* [yeoman/generator-angular](https://github.com/yeoman/generator-angular) - yeoman/generator-angular
-* [angular/angularjs-batarang](https://github.com/angular/batarang) - AngularJS WebInspector Extension for Chrome
-* [decipherinc/angular-debaser](https://github.com/decipherinc/angular-debaser/) - Just a better way to test AngularJS apps
+* [angular/protractor](https://github.com/angular/protractor) - E2E test framework for AngularJS apps.
+* [matthieu-D/angular-lorem-image](https://github.com/matthieu-D/angular-lorem-image) - This directive provides lorem image generation for your website by using the great lorempixel service to generate images.
+* [ajoslin/angular-promise-tracker](https://github.com/ajoslin/angular-promise-tracker) - Easily add spinners or general request tracking to your AngularJS app.
+* [yeoman/generator-angular](https://github.com/yeoman/generator-angular) - Yeoman generator for AngularJS apps.
+* [angular/angularjs-batarang](https://github.com/angular/batarang) - AngularJS WebInspector Extension for Chrome.
+* [decipherinc/angular-debaser](https://github.com/decipherinc/angular-debaser/) - Just a better way to test AngularJS apps.
 
 ## View
 * [AngularStrap](http://mgcrea.github.io/angular-strap/) - AngularJS native directives for Bootstrap.
 * [Angular UI](http://angular-ui.github.io/) - Angular UI is the companion suite(s) to the AngularJS framework.
-* [Augus/ngAnimate](https://github.com/Augus/ngAnimate) - ngAnimate is best effect solution made for AngularJS
-* [btford/angular-modal](https://github.com/btford/angular-modal) - Simple AngularJS service for creating modals
+* [Augus/ngAnimate](https://github.com/Augus/ngAnimate) - ngAnimate is best effect solution made for AngularJS.
+* [btford/angular-modal](https://github.com/btford/angular-modal) - Simple AngularJS service for creating modals.
 
 ## Service
-* [btford/angular-socket-io](https://github.com/btford/angular-socket-io) - Socket.IO component for AngularJS
-* [firebase/angularFire](https://github.com/firebase/angularFire) - AngularJS bindings for Firebase
-* [olov/ng-annotate](https://github.com/olov/ng-annotate) - Add, remove and rebuild AngularJS dependency injection annotations
+* [btford/angular-socket-io](https://github.com/btford/angular-socket-io) - Socket.IO component for AngularJS.
+* [firebase/angularFire](https://github.com/firebase/angularFire) - AngularJS bindings for Firebase.
+* [olov/ng-annotate](https://github.com/olov/ng-annotate) - Add, remove and rebuild AngularJS dependency injection annotations.
 * [pineconellc/angular-foundation](https://github.com/pineconellc/angular-foundation) - This project is a port of the AngularUI team's excellent angular-bootstrap project for use in the Foundation framework.
-* [kendo-labs/angular-kendo](https://github.com/kendo-labs/angular-kendo) - A project to create a robust set of Angular.js bindings for Kendo UI widgets
-* [angular-ui/angular-google-maps](https://github.com/angular-ui/angular-google-maps) - AngularJS directives for the Google Maps Javascript API
-* [luisfarzati/angulartics](https://github.com/luisfarzati/angulartics) - Analytics for AngularJS applications
-* [Ciul/angular-facebook](https://github.com/Ciul/angular-facebook) - An Angularjs module to take approach of Facebook javascript sdk
-* [pc035860/angular-easyfb](https://github.com/pc035860/angular-easyfb) - Super easy AngularJS + Facebook JavaScript SDK
+* [kendo-labs/angular-kendo](https://github.com/kendo-labs/angular-kendo) - A project to create a robust set of AngularJS bindings for Kendo UI widgets.
+* [angular-ui/angular-google-maps](https://github.com/angular-ui/angular-google-maps) - AngularJS directives for the Google Maps Javascript API.
+* [luisfarzati/angulartics](https://github.com/luisfarzati/angulartics) - Analytics for AngularJS applications.
+* [Ciul/angular-facebook](https://github.com/Ciul/angular-facebook) - An AngularJS module based approach to the Facebook Javascript SDK.
+* [pc035860/angular-easyfb](https://github.com/pc035860/angular-easyfb) - Super easy AngularJS + Facebook JavaScript SDK.
 
 ## Internationalization
-* [angular-translate/angular-translate](https://github.com/angular-translate/angular-translate) - i18n in your Angular apps, made easy
-* [rubenv/angular-gettext](https://github.com/rubenv/angular-gettext) - Translate your Angular.JS applications with gettext.
+* [angular-translate/angular-translate](https://github.com/angular-translate/angular-translate) - i18n in your AngularJS apps, made easy.
+* [rubenv/angular-gettext](https://github.com/rubenv/angular-gettext) - Translate your AngularJS applications with gettext.
 
 ## Chart
-* [n3-charts/line-chart](https://github.com/n3-charts/line-chart) - Awesome charts for AngularJS
-* [bouil/angular-google-chart](https://github.com/bouil/angular-google-chart) - Google Chart Tools AngularJS Directive Module
-* [chinmaymk/angular-charts](https://github.com/chinmaymk/angular-charts) - angular directives for creating common charts using d3
-* [carlcraig/tc-angular-chartjs](https://github.com/carlcraig/tc-angular-chartjs) - Add Chart.js charts to your angular application
-* [stpa-co/angular-morris-chart](https://github.com/stewones/angular-morris-chart) - Create morris chart easily with this directives
+* [n3-charts/line-chart](https://github.com/n3-charts/line-chart) - Awesome charts for AngularJS.
+* [bouil/angular-google-chart](https://github.com/bouil/angular-google-chart) - Google Chart Tools AngularJS Directive Module.
+* [chinmaymk/angular-charts](https://github.com/chinmaymk/angular-charts) - angular directives for creating common charts using d3.
+* [carlcraig/tc-angular-chartjs](https://github.com/carlcraig/tc-angular-chartjs) - Add Chart.js charts to your AngularJS application.
+* [stpa-co/angular-morris-chart](https://github.com/stewones/angular-morris-chart) - Create morris chart easily with this directives.
 
 ## Task
-* [ericclemmons/grunt-angular-templates](https://github.com/ericclemmons/grunt-angular-templates) - Grunt build task to concatenate & pre-load your AngularJS templates
-* [Kagami/gulp-ng-annotate](https://github.com/Kagami/gulp-ng-annotate) - Add angularjs dependency injection annotations with ng-annotate
-* [jeffling/ngmin-webpack-plugin](https://github.com/jeffling/ngmin-webpack-plugin) - Webpack plugin for injection of annotations (for pre-minimization)
+* [ericclemmons/grunt-angular-templates](https://github.com/ericclemmons/grunt-angular-templates) - Grunt build task to concatenate & pre-load your AngularJS templates.
+* [Kagami/gulp-ng-annotate](https://github.com/Kagami/gulp-ng-annotate) - Add AngularJS dependency injection annotations with ng-annotate.
+* [jeffling/ngmin-webpack-plugin](https://github.com/jeffling/ngmin-webpack-plugin) - Webpack plugin for injection of annotations (for pre-minimization).
 
 ## TodoMVC
-*[angular-dart](https://github.com/tastejs/todomvc/tree/master/examples/angular-dart)
-*[angular2](https://github.com/tastejs/todomvc/tree/master/examples/angular2)
-*[angularjs-perf](https://github.com/tastejs/todomvc/tree/master/examples/angularjs-perf)
-*[angularjs](https://github.com/tastejs/todomvc/tree/master/examples/angularjs)
-*[angularjs_require](https://github.com/tastejs/todomvc/tree/master/examples/angularjs_require)
-*[typescript-angular](https://github.com/tastejs/todomvc/tree/master/examples/typescript-angular)
+* [angular-dart](https://github.com/tastejs/todomvc/tree/master/examples/angular-dart)
+* [angular2](https://github.com/tastejs/todomvc/tree/master/examples/angular2)
+* [angularjs-perf](https://github.com/tastejs/todomvc/tree/master/examples/angularjs-perf)
+* [angularjs](https://github.com/tastejs/todomvc/tree/master/examples/angularjs)
+* [angularjs_require](https://github.com/tastejs/todomvc/tree/master/examples/angularjs_require)
+* [typescript-angular](https://github.com/tastejs/todomvc/tree/master/examples/typescript-angular)
 
 ## Other
-* [mgechev/angularjs-style-guide](https://github.com/mgechev/angularjs-style-guide) - Community-driven set of best practices for AngularJS application development
-* [shyamseshadri/angularjs-book](https://github.com/shyamseshadri/angularjs-book) - Examples and Code snippets from the AngularJS O'Reilly book
-* [johnpapa/angularjs-styleguide](https://github.com/johnpapa/angular-styleguide) - A starting point for Angular development teams to provide consistency through good practices
-* [angular-js.in](http://angular-js.in/) - A curated collection of angular directives
+* [mgechev/angularjs-style-guide](https://github.com/mgechev/angularjs-style-guide) - Community-driven set of best practices for AngularJS application development.
+* [shyamseshadri/angularjs-book](https://github.com/shyamseshadri/angularjs-book) - Examples and Code snippets from the AngularJS O'Reilly book.
+* [johnpapa/angularjs-styleguide](https://github.com/johnpapa/angular-styleguide) - A starting point for AngularJS development teams to provide consistency through good practices.
+* [angular-js.in](http://angular-js.in/) - A curated collection of AngularJS directives.
 * [mgechev/angularjs-in-patterns](https://github.com/mgechev/angularjs-in-patterns) - This repository provides different look into AngularJS.
-* [Gillespie59/eslint-plugin-angular](https://github.com/Gillespie59/eslint-plugin-angular) - ESLint plugin for AngularJS application
-* [kasperlewau/angular-bind-notifier](https://github.com/kasperlewau/angular-bind-notifier) - Low $watch count namespaced Angular bindings, i.e. refreshment of one-way binds.
+* [Gillespie59/eslint-plugin-angular](https://github.com/Gillespie59/eslint-plugin-angular) - ESLint plugin for AngularJS application.
+* [kasperlewau/angular-bind-notifier](https://github.com/kasperlewau/angular-bind-notifier) - Low $watch count namespaced AngularJS bindings, i.e. refreshment of one-way binds.
 
 ## License
 


### PR DESCRIPTION
The format update was pretty basic. Ensure periods were used at the end
of lines, align all occurrances of
angular/angular.js/angularjs/Angular/AngularJS to the same thing
(AngularJS, the same way they spell it), and fix the bullet points for
the TodoMVC section.

I also navigated to each link and made sure it existed and was not
marked as _deprecated_ or _unmaintained_. Those that were deprecated,
missing, or extremely old have been removed. Unmaintained projects have
been marked with `(_unmaintained_)` after the description.